### PR TITLE
feat: safely load `tags` from data contract

### DIFF
--- a/dagster_datacontract/__init__.py
+++ b/dagster_datacontract/__init__.py
@@ -74,8 +74,10 @@ class DataContractLoader:
         More information about Dagster tags:
         https://docs.dagster.io/guides/build/assets/metadata-and-tags/tags
         """
+        key_pattern = re.compile(r"^[\w.-]{1,63}$")
+        val_pattern = re.compile(r"^[\w.-]{0,63}$")
+
         tags = {}
-        pattern = re.compile(r"^[\w.-]{1,63}$")
 
         for item in self.data_contract_specification.tags:
             if ":" in item:
@@ -83,7 +85,7 @@ class DataContractLoader:
             else:
                 key, val = item.strip(), ""
 
-            if pattern.match(key) and pattern.match(val):
+            if key_pattern.match(key) and val_pattern.match(val):
                 tags[key] = val
             else:
                 logger.warning(f"Ignoring invalid tag: {item}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10.0"
 dependencies = [
     "dagster>=1.10.10",
     "datacontract-cli>=0.10.23",
+    "loguru>=0.7.3",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,7 @@ source = { editable = "." }
 dependencies = [
     { name = "dagster" },
     { name = "datacontract-cli" },
+    { name = "loguru" },
 ]
 
 [package.dev-dependencies]
@@ -333,6 +334,7 @@ dev = [
 requires-dist = [
     { name = "dagster", specifier = ">=1.10.10" },
     { name = "datacontract-cli", specifier = ">=0.10.23" },
+    { name = "loguru", specifier = ">=0.7.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -892,6 +894,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256 },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595 },
 ]
 
 [[package]]
@@ -2252,6 +2267,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155 },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884 },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083 },
 ]
 
 [[package]]


### PR DESCRIPTION
Ensure that the `tags` loaded from the data contract follows the rules defined by Dagster:

- Be 63 characters or less
- Contain only alphanumeric characters, dashes (`-`), underscores (`_`), and dots (`.`)

Reference: [https://docs.dagster.io/guides/build/assets/metadata-and-tags/tags](https://docs.dagster.io/guides/build/assets/metadata-and-tags/tags).